### PR TITLE
Allow connecting to internet using tue-wpa2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__
 **/*.swp
 sd-card/
+deploy/files/wpa_supplicant.conf.tue-wpa2

--- a/deploy/files/install.sh
+++ b/deploy/files/install.sh
@@ -7,7 +7,12 @@
 
 echo "Switching to Tue-guest network to update system, you will experience a momentary connection drop!"
 sudo cp /etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf.old
-sudo cp wpa_supplicant.conf.tue_guest /etc/wpa_supplicant/wpa_supplicant.conf
+if [ -f wpa_supplicant.conf.tue-wpa2 ]; then
+    echo "Using tue-wpa2 credentials"
+    sudo cp wpa_supplicant.conf.tue-wpa2 /etc/wpa_supplicant/wpa_supplicant.conf
+else
+    sudo cp wpa_supplicant.conf.tue_guest /etc/wpa_supplicant/wpa_supplicant.conf
+fi
 sudo wpa_cli -i wlan0 reconfigure
 sudo wpa_cli -i wlan0 reconnect
 sleep 1

--- a/deploy/files/install.sh
+++ b/deploy/files/install.sh
@@ -5,19 +5,20 @@
 # Author: Daan de Graaf
 #
 
-echo "Switching to Tue-guest network to update system, you will experience a momentary connection drop!"
+echo "Switching network to update system, you will experience a momentary connection drop!"
 sudo cp /etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf.old
 if [ -f wpa_supplicant.conf.tue-wpa2 ]; then
     echo "Using tue-wpa2 credentials"
     sudo cp wpa_supplicant.conf.tue-wpa2 /etc/wpa_supplicant/wpa_supplicant.conf
 else
+    echo "Using TUe_guest open network"
     sudo cp wpa_supplicant.conf.tue_guest /etc/wpa_supplicant/wpa_supplicant.conf
 fi
 sudo wpa_cli -i wlan0 reconfigure
 sudo wpa_cli -i wlan0 reconnect
 sleep 1
 
-echo "Logging in to portal"
+echo "Verifying connectivity"
 
 until $(curl --output /dev/null --silent --head --fail https://google.com); do
     sleep 1

--- a/deploy/files/wpa_supplicant.conf.test
+++ b/deploy/files/wpa_supplicant.conf.test
@@ -1,8 +1,0 @@
-ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
-update_config=1
-country=GB
-
-network={
-    ssid="test"
-    key_mgmt=NONE
-}

--- a/deploy/wpa_supplicant.conf.tue-wpa2.template
+++ b/deploy/wpa_supplicant.conf.tue-wpa2.template
@@ -1,0 +1,10 @@
+network={
+        ssid="tue-wpa2"
+        scan_ssid=1
+        key_mgmt=WPA-EAP
+        eap=PEAP
+        identity="$username"
+        password="$password"
+        phase1="peaplabel=0"
+        phase2="auth=MSCHAPV2"
+}


### PR DESCRIPTION
Allows the user to supply TUe credentials to have pi's login via tue-wpa2 instead of the guest network, which is typically less stable